### PR TITLE
development.keyを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/credentials/development.key
 
 /app/assets/builds/*
 !/app/assets/builds/.keep


### PR DESCRIPTION
## 概要
- プロトタイプで生成した開発用 credentials キーをそのまま使用するため、`development.key`を`.gitignore`に追加しました。