### PR TITLE
アプリケーションモジュール名称を SkincareResumeApp に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module SkincareResume
+module SkincareResumeApp
   class Application < Rails::Application
     config.i18n.default_locale = :ja
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
## 概要
- プロトタイプ開発時に SkincareResume モデルとアプリケーションのルートモジュール名が衝突することに気づいたため、本開発ではクラス定義前にルートモジュール名を SkincareResumeApp に変更しました。