### PR TITLE
Rubocop の Lint を CI で実行するように設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: Rails Lint
 
 on:
-  pull_request:
   push:
 
 jobs:


### PR DESCRIPTION
## Issue
- #7 

## 概要
- Rubocop の Lint を CI で実行するように設定しました。