### PR TITLE
入力（確認）ページの作成

### DIFF
--- a/app/controllers/skincare_resumes_controller.rb
+++ b/app/controllers/skincare_resumes_controller.rb
@@ -1,71 +1,28 @@
 # frozen_string_literal: true
 
 class SkincareResumesController < ApplicationController
-  before_action :set_skincare_resume, only: %i[show edit update destroy]
+  PRODUCTS_MAX_SIZE = 10
+  MEDICATIONS_MAX_SIZE = 5
+  ALLERGIES_MAX_SIZE = 5
+  TREATMENTS_MAX_SIZE = 20
 
-  # GET /skincare_resumes or /skincare_resumes.json
-  def index
-    @skincare_resumes = SkincareResume.all
-  end
+  def confirmation
+    resume = current_user.skincare_resume
 
-  # GET /skincare_resumes/1 or /skincare_resumes/1.json
-  def show; end
+    products = resume ? resume.products.order(:started_on) : []
+    medications = resume ? resume.medications.order(:started_on) : []
+    allergies = resume ? resume.allergies : []
+    treatments = resume ? resume.treatments.order(:treated_on) : []
 
-  # GET /skincare_resumes/new
-  def new
-    @skincare_resume = SkincareResume.new
-  end
-
-  # GET /skincare_resumes/1/edit
-  def edit; end
-
-  # POST /skincare_resumes or /skincare_resumes.json
-  def create
-    @skincare_resume = SkincareResume.new(skincare_resume_params)
-
-    respond_to do |format|
-      if @skincare_resume.save
-        format.html { redirect_to @skincare_resume, notice: 'Skincare resume was successfully created.' }
-        format.json { render :show, status: :created, location: @skincare_resume }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @skincare_resume.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PATCH/PUT /skincare_resumes/1 or /skincare_resumes/1.json
-  def update
-    respond_to do |format|
-      if @skincare_resume.update(skincare_resume_params)
-        format.html { redirect_to @skincare_resume, notice: 'Skincare resume was successfully updated.', status: :see_other }
-        format.json { render :show, status: :ok, location: @skincare_resume }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @skincare_resume.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # DELETE /skincare_resumes/1 or /skincare_resumes/1.json
-  def destroy
-    @skincare_resume.destroy!
-
-    respond_to do |format|
-      format.html { redirect_to skincare_resumes_path, notice: 'Skincare resume was successfully destroyed.', status: :see_other }
-      format.json { head :no_content }
-    end
+    @products = format(products, PRODUCTS_MAX_SIZE) { Product.new }
+    @medications = format(medications, MEDICATIONS_MAX_SIZE) { Medication.new }
+    @allergies = format(allergies, ALLERGIES_MAX_SIZE) { Allergy.new }
+    @treatments = format(treatments, TREATMENTS_MAX_SIZE) { Treatment.new }
   end
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
-  def set_skincare_resume
-    @skincare_resume = SkincareResume.find(params.expect(:id))
-  end
-
-  # Only allow a list of trusted parameters through.
-  def skincare_resume_params
-    params.expect(skincare_resume: %i[user_id status uuid])
+  def format(list, max, &block)
+    list.to_a + Array.new([max - list.size, 0].max, &block)
   end
 end

--- a/app/views/skincare_resumes/confirmation.html.slim
+++ b/app/views/skincare_resumes/confirmation.html.slim
@@ -1,0 +1,68 @@
+- content_for :title, '入力したスキンケアの履歴書の確認'
+
+.w-full.max-w-4xl.mx-auto
+  .my-8.mx-auto.px-4
+    h3.font-medium.text-center.text-xl
+      | 入力したスキンケアの履歴書の確認
+
+  .my-4.w-full.max-w-2xl.mx-auto
+    h3.text-md.sm:text-xl
+      = "スキンケアの履歴書 (最終更新日: #{l(Time.zone.today, format: :default)})"
+
+    table.table-fixed.w-full.my-4.border.text-sm
+      thead
+        tr
+          th.w-32.border.px-4.py-2.text-center 使用開始日
+          th.border.px-4.py-2.text-left スキンケア製品名
+      tbody
+        - @products.each do |product|
+          tr.h-8
+            td.border.px-4.py-2.text-center
+              - if product.name
+                = product.started_on ? l(product.started_on, format: :default) : '－'
+              - else
+                = ''
+            td.border.px-4.py-2.text-left
+              = product.name
+
+    table.table-fixed.w-full.my-4.border.text-sm
+      thead
+        tr
+          th.w-32.border.px-4.py-2.text-center 使用開始日
+          th.border.px-4.py-2.text-left 薬名
+      tbody
+        - @medications.each do |medication|
+          tr.h-8
+            td.border.px-4.py-2.text-center
+              - if medication.name
+                = medication.started_on ? l(medication.started_on) : '－'
+              - else
+                = ''
+            td.border.px-4.py-2.text-left
+              = medication.name
+
+    table.table-fixed.w-full.my-4.border.text-sm
+      thead
+        tr
+          th.border.px-4.py-2.text-left アレルギー名
+      tbody
+        - @allergies.each do |allergy|
+          tr.h-8
+            td.border.px-4.py-2.text-left
+              = allergy.name
+
+    table.table-fixed.w-full.my-4.mt-48.border.text-sm
+      thead
+        tr
+          th.w-32.border.px-4.py-2.text-center 施術日
+          th.border.px-4.py-2.text-left 治療名
+      tbody
+        - @treatments.each do |treatment|
+          tr.h-8
+            td.border.px-4.py-2.text-center
+              - if treatment.name
+                = treatment.treated_on ? l(treatment.treated_on, format: :default) : '－'
+              - else
+                = ''
+            td.border.px-4.py-2.text-left
+              = treatment.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,10 @@ Rails.application.routes.draw do
   resources :allergies
   resources :medications
   resources :products
-  resources :skincare_resumes
+
+  resource :skincare_resume do
+    get :confirmation
+  end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## Issue
- #95 

## 概要
- ログインユーザー向けの入力内容確認ページを実装しました。

## 仕様
### ログインユーザーのデータ管理
- スキンケア / 薬 / アレルギー / 治療履歴の入力内容は、登録 / 更新 / 削除により、各DBが更新されます。
- スキンケア / 薬 / アレルギー / 治療履歴を最初に登録したタイミングで `SkincareResume` を新規作成し、その`UUID`をセッションに保存します。
- データ操作は `current_user.skincare_resume` を起点に行います。

## スクリーンショット
<img width="1918" height="1017" alt="image" src="https://github.com/user-attachments/assets/eb4d9c9c-476c-4809-9547-9dc09aa9a402" />
<img width="1918" height="491" alt="image" src="https://github.com/user-attachments/assets/8c486261-3ad6-4aca-b789-6e687930878d" />
<img width="1918" height="988" alt="image" src="https://github.com/user-attachments/assets/1a20f70e-ad80-4f67-a52d-cffce03757f8" />
