### PR TITLE
トップページに戻るボタンを追加

### DIFF
--- a/app/controllers/skincare_resumes_controller.rb
+++ b/app/controllers/skincare_resumes_controller.rb
@@ -31,6 +31,11 @@ class SkincareResumesController < ApplicationController
     end
   end
 
+  def destroy
+    session.delete('resume_uuid')
+    redirect_to root_path
+  end
+
   private
 
   def format(list, max, &block)

--- a/app/views/allergies/index.html.slim
+++ b/app/views/allergies/index.html.slim
@@ -39,3 +39,8 @@
       = link_to 'トップページに戻る',
                 root_path,
                 class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'
+    - else
+      = form_with url: skincare_resume_path,
+                  method: :delete,
+                  data: { turbo_confirm: '入力内容は保存されませんが、トップページに戻りますか？' } do |form|
+        = form.submit 'トップページに戻る', class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'

--- a/app/views/medications/index.html.slim
+++ b/app/views/medications/index.html.slim
@@ -39,3 +39,8 @@
       = link_to 'トップページに戻る',
                 root_path,
                 class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'
+    - else
+      = form_with url: skincare_resume_path,
+                  method: :delete,
+                  data: { turbo_confirm: '入力内容は保存されませんが、トップページに戻りますか？' } do |form|
+        = form.submit 'トップページに戻る', class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -39,3 +39,8 @@
       = link_to 'トップページに戻る',
                 root_path,
                 class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'
+    - else
+      = form_with url: skincare_resume_path,
+                  method: :delete,
+                  data: { turbo_confirm: '入力内容は保存されませんが、トップページに戻りますか？' } do |form|
+        = form.submit 'トップページに戻る', class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'

--- a/app/views/skincare_resumes/confirmation.html.slim
+++ b/app/views/skincare_resumes/confirmation.html.slim
@@ -87,3 +87,8 @@
       = link_to 'トップページに戻る',
                 root_path,
                 class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'
+    - else
+      = form_with url: skincare_resume_path,
+                  method: :delete,
+                  data: { turbo_confirm: '入力内容は保存されませんが、トップページに戻りますか？' } do |form|
+        = form.submit 'トップページに戻る', class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'

--- a/app/views/treatments/index.html.slim
+++ b/app/views/treatments/index.html.slim
@@ -39,3 +39,8 @@
       = link_to 'トップページに戻る',
                 root_path,
                 class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'
+    - else
+      = form_with url: skincare_resume_path,
+                  method: :delete,
+                  data: { turbo_confirm: '入力内容は保存されませんが、トップページに戻りますか？' } do |form|
+        = form.submit 'トップページに戻る', class: 'w-40 rounded-md text-center px-3.5 py-2 bg-[#5F7F67] hover:bg-[#4A6652] text-white font-medium'


### PR DESCRIPTION
## Issue
- #129 

## 概要
- 入力ページ(スキンケア製品 / 薬 / アレルギー / 治療履歴)に「トップページに戻る」ボタンを追加しました。
- ログイン時は、ボタンクリック後、履歴書の作成状況に応じたトップページに遷移します。
- 未ログイン時は、ボタンクリック後、セッションに保持しているUUIDを削除してから、トップページ(ログイン前)に遷移します。

## スクリーンショット
### 履歴書：作成前、ログイン：済
- 「トップページに戻る」ボタンをクリック後、トップページ(ログイン後・履歴書作成前)に遷移する。
<img width="1918" height="1091" alt="image" src="https://github.com/user-attachments/assets/b87f5f09-b906-41cb-bf9e-d8ad0058e7cc" />

<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/7270db94-2178-4f05-9757-cdbe9f0696cb" />

### 履歴書：作成前、ログイン：未
- 「トップページに戻る」ボタンをクリック後、トップページ(ログイン前)に遷移する。
<img width="1918" height="1092" alt="image" src="https://github.com/user-attachments/assets/b1ecc3d9-1979-4d82-974d-4f33a7b0db49" />

<img width="1918" height="1082" alt="image" src="https://github.com/user-attachments/assets/f785fbed-8977-40d5-a83c-0ef7bfa7bf3b" />

<img width="1918" height="1090" alt="image" src="https://github.com/user-attachments/assets/a528f4fa-6424-4606-ad3b-b0792114c97a" />


### 履歴書：作成途中、ログイン：済
- 「トップページに戻る」ボタンをクリック後、トップページ(ログイン後・履歴書途中)に遷移する。
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/62f5f8d9-c498-41cf-957d-ddb48d80a790" />

<img width="1918" height="1092" alt="image" src="https://github.com/user-attachments/assets/862ebf5d-a0ec-43dd-8f92-e9f4616f3447" />

### 履歴書：作成完了、ログイン：済
- 「トップページに戻る」ボタンをクリック後、トップページ(ログイン後・履歴書完了)に遷移する。
<img width="1918" height="1090" alt="image" src="https://github.com/user-attachments/assets/28e916ff-b448-4cfd-bd2a-a34ba46e9873" />

<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/8959ec84-60ae-423b-8481-321a57f0baca" />

## 状態遷移
### 入力ページまでの遷移
| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| トップページ（ログイン前）にアクセス | 「Googleアカウントでログイン」ボタンをクリック | トップページ（ログイン後・作成前）に遷移 | 「履歴書を新規作成する」ボタンをクリック | 入力ページ(スキンケア)に遷移 |
| ↑ | ↑ | トップページ（ログイン後・作成途中）に遷移 | 「作成途中の履歴書を編集・更新する」ボタンをクリック | ↑ |
| ↑ | ↑ | トップページ（ログイン後・作成後）に遷移 | 「作成した履歴書を編集・更新する」ボタンをクリック | ↑ |
| ↑ | 「ログインせずに履歴書を作成」ボタンをクリック | － | － | ↑ |

### 履歴書：作成前、ログイン：済

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| 「履歴書を新規作成する」ボタンをクリック | スキンケア/薬/アレルギー/治療履歴を入力 | 入力内容を確認 | 「履歴書を完成させる」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成途中）に遷移 |
| ↑ | 何も入力しない | － | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成前）に遷移 |

### 履歴書：作成前、ログイン：未

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| 「ログインせずに履歴書を作成」ボタンをクリック | スキンケア/薬/アレルギー/治療履歴を入力 | 入力内容を確認 | 「保存」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「一時保存」ボタンをクリック | トップページ（ログイン後・作成途中）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン前）に遷移 |
| ↑ | 何も入力しない | － | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン前）に遷移 |

### 履歴書：作成途中、ログイン：済

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| 「作成途中の履歴書を編集・更新する」ボタンをクリック | スキンケア/薬/アレルギー/治療履歴を入力 | 入力内容を確認 | 「履歴書を完成させる」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成途中）に遷移 |
| ↑ | 何も変更しない | ー | 「履歴書を完成させる」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成途中）に遷移 |

### 履歴書：作成後、ログイン：済

| 1 | 2 | 3 | 4 | 5 |
| - | - | - | - | - |
| 「作成した履歴書を編集・更新する」ボタンをクリック | スキンケア/薬/アレルギー/治療履歴を入力 | 入力内容を確認 | 「履歴書を完成させる」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | 何も変更しない | ー | 「履歴書を完成させる」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |
| ↑ | ↑ | ↑ | 「トップページへ戻る」ボタンをクリック | トップページ（ログイン後・作成後）に遷移 |

## 未対応・仕様検討事項
- 下記は本PRでは未対応で、別途対応・検討予定です。
  - 未入力で保存・完成ボタンをクリックした場合の仕様検討(現状エラー)
