### PR TITLE
body に背景色と文字色を追加

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -18,7 +18,7 @@ html
     = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
 
-  body class='flex flex-col min-h-screen'
+  body class='flex flex-col min-h-screen bg-[#FDFDFD] text-[#2C4242]'
     #flash.fixed.top-5.right-5.z-50
       = render 'flash'
 


### PR DESCRIPTION
## Issue
- #10 

## 概要
- body にバックグランドカラー(`#FDFDFD`)とテキストカラー(`#2C4242`)の指定を追加しました。

## スクリーンショット
- 見た目上の大きな変化はないため、省略いたします。
