### PR TITLE
ドメイン名をsjabcdefin.comからskincare-resume.comに変更

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,10 +2,10 @@ service: skincare-resume-app
 image: sjabcdefin/skincare-resume-app
 servers:
   web:
-    - sjabcdefin.com
+    - skincare-resume.com
 proxy:
   ssl: true
-  host: sjabcdefin.com
+  host: skincare-resume.com
   app_port: 3000
 registry:
   username: sjabcdefin


### PR DESCRIPTION
## Issue
- #139 

## 概要
- ドメイン名を`sjabcdefin.com`から`skincare-resume.com`に変更しました。

## スクリーンショット
- ドメイン名の変更のみのため、省略いたします。