### PR TITLE
編集フォームの「登録する」「キャンセル」のボタン位置を入替

### DIFF
--- a/app/views/allergies/_form.html.slim
+++ b/app/views/allergies/_form.html.slim
@@ -13,11 +13,11 @@
               = "アレルギー名#{allergy.errors[:name].first}。"
 
       .flex.space-x-2.justify-between.sm:shrink-0
-        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
         = link_to 'キャンセル',
                   allergies_path,
                   data: { turbo_frame: form_frame_for(allergy) },
                   class: 'inline-flex items-center justify-center h-10 w-24 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 text-base font-normal'
+        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
 
     - if allergy.persisted?
       = form.submit '✕',

--- a/app/views/medications/_form.html.slim
+++ b/app/views/medications/_form.html.slim
@@ -19,11 +19,11 @@
               = "薬の名前#{medication.errors[:name].first}。"
 
       .flex.space-x-2.justify-between.sm:shrink-0
-        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
         = link_to 'キャンセル',
                   medications_path,
                   data: { turbo_frame: form_frame_for(medication) },
                   class: 'inline-flex items-center justify-center h-10 w-24 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 text-base font-normal'
+        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
 
     - if medication.persisted?
       = form.submit '✕',

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -19,11 +19,11 @@
               = "スキンケア製品名#{product.errors[:name].first}。"
 
       .flex.space-x-2.justify-between.sm:shrink-0
-        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
         = link_to 'キャンセル',
                   products_path,
                   data: { turbo_frame: form_frame_for(product) },
                   class: 'inline-flex items-center justify-center h-10 w-24 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 text-base font-normal'
+        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
 
     - if product.persisted?
       = form.submit '✕',

--- a/app/views/treatments/_form.html.slim
+++ b/app/views/treatments/_form.html.slim
@@ -19,11 +19,11 @@
               = "治療名#{treatment.errors[:name].first}。"
 
       .flex.space-x-2.justify-between.sm:shrink-0
-        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
         = link_to 'キャンセル',
                   treatments_path,
                   data: { turbo_frame: form_frame_for(treatment) },
                   class: 'inline-flex items-center justify-center h-10 w-24 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 text-base font-normal'
+        = form.submit class: 'inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] text-base font-normal text-white'
 
     - if treatment.persisted?
       = form.submit '✕',


### PR DESCRIPTION
## Issue
- #159 

## 概要
- 編集フォームの「登録する」「キャンセル」のボタン位置を入れ替えました。

## スクリーンショット
<img width="1918" height="1091" alt="image" src="https://github.com/user-attachments/assets/94a20373-d301-48e3-bdab-42e67c2e282d" />
