### PR TITLE
SkincareResumesControllerの未使用なインスタンス変数を削除

### DIFF
--- a/app/controllers/skincare_resumes_controller.rb
+++ b/app/controllers/skincare_resumes_controller.rb
@@ -8,9 +8,8 @@ class SkincareResumesController < ApplicationController
   end
 
   def update
-    @resume = repository.resume
+    repository.resume.update!(status_params)
     redirect_path = current_user ? root_path : '/auth/google_oauth2'
-    @resume.update!(status_params)
 
     redirect_to redirect_path, notice: '履歴書の登録を完了しました。'
   end


### PR DESCRIPTION
## 概要
- SkincareResumesController#update 内の未使用なインスタンス変数: `@resume` を削除しました。

## スクリーンショット
- 内部処理の変更であり、見た目上の変更はないため、省略いたします。