### PR TITLE
フッターの turbo_confirm を i18n 対応した

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -38,9 +38,9 @@ html
         - if current_user
           = link_to t('footer.logout'),
                     logout_path,
-                    data: { turbo_method: :post, turbo_confirm: 'ログアウトしますか？' },
+                    data: { turbo_method: :post, turbo_confirm: t('footer.logout_confirmation') },
                     class: 'hover:border-b'
           = link_to t('footer.acount_delete'),
                     account_path,
-                    data: { turbo_method: :delete, turbo_confirm: '本当にアカウントを削除しますか？' },
+                    data: { turbo_method: :delete, turbo_confirm: t('footer.account_delete_confirmation') },
                     class: 'hover:border-b'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -101,7 +101,9 @@ ja:
     terms: 利用規約
     privacy: プライバシーポリシー
     logout: ログアウト
+    logout_confirmation: ログアウトしますか？
     acount_delete: アカウント削除
+    account_delete_confirmation: 本当にアカウントを削除しますか？
   flash:
     create:
       success: 登録されました。


### PR DESCRIPTION
## Issue
- #161 

## 概要
- フッターの turbo_confirm を i18n 対応しました。

## 主な変更点
- フッターの「ログアウト」リンククリック時の「ログアウトしますか？」を i18n 対応しました。
- フッターの「アカウント削除」リンククリック時の「本当にアカウント削除しますか？」を i18n 対応しました。

## スクリーンショット
- 内部処理の変更であり、見た目上の変更はないため省略いたします。