### PR TITLE
各入力ページでの登録/更新/削除時のフラッシュメッセージを削除

### DIFF
--- a/app/views/allergies/create.turbo_stream.slim
+++ b/app/views/allergies/create.turbo_stream.slim
@@ -1,6 +1,5 @@
 = turbo_stream.append 'allergies', @allergy
 = turbo_stream.update Allergy.new, ''
-= turbo_stream_flash
 
 = turbo_stream.replace 'save_button' do
   = render 'shared/resume_save_button', resume: @resume, next_action: :draft

--- a/app/views/allergies/destroy.turbo_stream.slim
+++ b/app/views/allergies/destroy.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.remove @allergy
-= turbo_stream_flash

--- a/app/views/allergies/update.turbo_stream.slim
+++ b/app/views/allergies/update.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.replace @allergy
-= turbo_stream_flash

--- a/app/views/medications/create.turbo_stream.slim
+++ b/app/views/medications/create.turbo_stream.slim
@@ -1,6 +1,5 @@
 = turbo_stream.append 'medications', @medication
 = turbo_stream.update Medication.new, ''
-= turbo_stream_flash
 
 = turbo_stream.replace 'save_button' do
   = render 'shared/resume_save_button', resume: @resume, next_action: :draft

--- a/app/views/medications/destroy.turbo_stream.slim
+++ b/app/views/medications/destroy.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.remove @medication
-= turbo_stream_flash

--- a/app/views/medications/update.turbo_stream.slim
+++ b/app/views/medications/update.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.replace @medication
-= turbo_stream_flash

--- a/app/views/products/create.turbo_stream.slim
+++ b/app/views/products/create.turbo_stream.slim
@@ -1,6 +1,5 @@
 = turbo_stream.append 'products', @product
 = turbo_stream.update Product.new, ''
-= turbo_stream_flash
 
 = turbo_stream.replace 'save_button' do
   = render 'shared/resume_save_button', resume: @resume, next_action: :draft

--- a/app/views/products/destroy.turbo_stream.slim
+++ b/app/views/products/destroy.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.remove @product
-= turbo_stream_flash

--- a/app/views/products/update.turbo_stream.slim
+++ b/app/views/products/update.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.replace @product
-= turbo_stream_flash

--- a/app/views/treatments/create.turbo_stream.slim
+++ b/app/views/treatments/create.turbo_stream.slim
@@ -1,6 +1,5 @@
 = turbo_stream.append 'treatments', @treatment
 = turbo_stream.update Treatment.new, ''
-= turbo_stream_flash
 
 = turbo_stream.replace 'save_button' do
   = render 'shared/resume_save_button', resume: @resume, next_action: :draft

--- a/app/views/treatments/destroy.turbo_stream.slim
+++ b/app/views/treatments/destroy.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.remove @treatment
-= turbo_stream_flash

--- a/app/views/treatments/update.turbo_stream.slim
+++ b/app/views/treatments/update.turbo_stream.slim
@@ -1,2 +1,1 @@
 = turbo_stream.replace @treatment
-= turbo_stream_flash


### PR DESCRIPTION
## Issue
- #179

## 概要
- 画面を見れば変更が明確で、冗長な情報であると考え、入力ページ(スキンケア製品 / 薬 /アレルギー / 治療履歴)での登録/更新/削除時のフラッシュメッセージを削除しました。