### PR TITLE
入力ページの幅を調整

### DIFF
--- a/app/views/allergies/index.html.slim
+++ b/app/views/allergies/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t('common.title', model: Allergy.model_name.human)
 
-.w-full.max-w-4xl.mx-auto
+.w-full.max-w-3xl.mx-auto
   = render 'shared/progress_bar'
 
   .my-8.px-4.space-y-3

--- a/app/views/medications/index.html.slim
+++ b/app/views/medications/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t('common.title', model: Medication.model_name.human)
 
-.w-full.max-w-4xl.mx-auto
+.w-full.max-w-3xl.mx-auto
   = render 'shared/progress_bar'
 
   .my-8.px-4.space-y-3

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t('common.title', model: Product.model_name.human)
 
-.w-full.max-w-4xl.mx-auto
+.w-full.max-w-3xl.mx-auto
   = render 'shared/progress_bar'
 
   .my-8.px-4.space-y-3

--- a/app/views/skincare_resumes/confirmation.html.slim
+++ b/app/views/skincare_resumes/confirmation.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t('.title')
 
-.w-full.max-w-4xl.mx-auto
+.w-full.max-w-2xl.mx-auto
   .my-5.print:hidden
     = render 'shared/progress_bar'
 

--- a/app/views/treatments/index.html.slim
+++ b/app/views/treatments/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, t('common.title', model: Treatment.model_name.human)
 
-.w-full.max-w-4xl.mx-auto
+.w-full.max-w-3xl.mx-auto
   = render 'shared/progress_bar'
 
   .my-8.px-4.space-y-3


### PR DESCRIPTION
## 概要
- 入力ページ（スキンケア製品 / 薬 / アレルギー / 治療履歴 / 確認）の幅：`max-width`を調整しました。

## スクリーンショット
### 変更前
<img width="1918" height="1085" alt="image" src="https://github.com/user-attachments/assets/a4a4e7c2-5792-4d95-a286-905b8c9a46ca" />
<img width="1918" height="1082" alt="image" src="https://github.com/user-attachments/assets/c111212b-b421-477b-9022-b20553991885" />

### 変更後
<img width="1918" height="1081" alt="image" src="https://github.com/user-attachments/assets/2bf11a92-53c7-4735-b5dc-0d83cfaf04b4" />
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/cbd218be-5c55-40b9-ab8a-3f8ffe3adb53" />
