### PR TITLE
入力・編集フォームの枠線の色を変更

### DIFF
--- a/app/views/allergies/_form.html.slim
+++ b/app/views/allergies/_form.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(allergy) do
-  = form_with(model: allergy, class: 'relative mx-auto max-w-4xl my-3 px-6 pt-12 pb-6 sm:pt-6 bg-white border border-gray-400 shadow') do |form|
+  = form_with(model: allergy, class: 'relative mx-auto max-w-4xl my-3 px-6 pt-12 pb-6 sm:pt-6 bg-white border border-[#5F7F67]0 shadow') do |form|
     .flex.flex-col.gap-4.sm:flex-row.sm:items-end
       .w-full
         .max-w-md.mb-2.space-y-2

--- a/app/views/medications/_form.html.slim
+++ b/app/views/medications/_form.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(medication) do
-  = form_with(model: medication, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-gray-400 shadow') do |form|
+  = form_with(model: medication, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-[#5F7F67] shadow') do |form|
     .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
       .w-full.space-y-3
         .max-w-md.space-y-2

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(product) do
-  = form_with(model: product, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-gray-400 shadow') do |form|
+  = form_with(model: product, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-[#5F7F67] shadow') do |form|
     .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
       .w-full.space-y-3
         .max-w-md.space-y-2

--- a/app/views/treatments/_form.html.slim
+++ b/app/views/treatments/_form.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag dom_id(treatment) do
-  = form_with(model: treatment, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-gray-400 shadow') do |form|
+  = form_with(model: treatment, class: 'relative mx-auto max-w-4xl mb-3 px-6 pt-12 sm:pt-6 bg-white border border-[#5F7F67] shadow') do |form|
     .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
       .w-full.space-y-3
         .max-w-md.space-y-2


### PR DESCRIPTION
## 概要
- 対象フォームの位置が分かりやすくするため、入力・編集フォームの枠線の色を変更しました。

## スクリーンショット
### 変更前
<img width="1918" height="1085" alt="image" src="https://github.com/user-attachments/assets/2e49eac8-f488-493c-83a7-3ef0347becde" />

### 変更後
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/86b6e75a-ae81-488c-b092-680cf07ed7aa" />
