### PR TITLE
ご利用方法が表示されない問題を修正

### DIFF
--- a/app/views/home/_before_login.html.slim
+++ b/app/views/home/_before_login.html.slim
@@ -21,7 +21,7 @@
 
 .max-w-2xl.mx-auto.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
   p.mt-4.text-base.font-bold.sm:text-xl
-    = t('common.usage.title')
+    = t('common.usage')
   p.my-4.mx-4.text-sm.sm:text-base
     | ログインなしでもすぐに使えます。
     br.sm:hidden

--- a/app/views/home/_no_resume.html.slim
+++ b/app/views/home/_no_resume.html.slim
@@ -22,7 +22,7 @@
 
 .max-w-2xl.mx-auto.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
   p.mt-4.text-base.font-bold.sm:text-xl
-    = t('common.usage.title')
+    = t('common.usage')
   p.my-4.mx-4.text-sm.sm:text-base
     | 「履歴書を新規作成する」ボタンから、すぐに入力を始められます。
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -115,6 +115,7 @@ ja:
     delete_confirmation: 本当に削除しますか？
     date_blank: －
     required_mark: "*"
+    usage: 💡 ご利用方法
   date:
     abbr_day_names:
       - 日


### PR DESCRIPTION
## 概要
- ご利用方法が表示されない問題を修正しました。

## 主な変更点
- #186 にて誤って削除してしまったため、ja.yml に `common.usage` を追加しました。

## スクリーンショット
### 変更前
<img width="1918" height="1092" alt="image" src="https://github.com/user-attachments/assets/3c38d598-bad9-4d53-b5c2-ac778dbc063e" />

### 変更後
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/0e00d022-6c16-48f9-834e-e9964b31a03c" />
