### PR TITLE
印刷時に印刷対象外のアレルギーが表示される不具合の修正

### DIFF
--- a/app/services/resume_formatter.rb
+++ b/app/services/resume_formatter.rb
@@ -25,7 +25,7 @@ class ResumeFormatter
 
   def allergy_rows
     allergies = @resume&.allergies || Allergy.none
-    format(allergies, ALLERGIES_MAX_SIZE) { Allergy.new }
+    format(sort_and_limit(allergies, ALLERGIES_MAX_SIZE), ALLERGIES_MAX_SIZE) { Allergy.new }
   end
 
   def treatment_rows


### PR DESCRIPTION
## 概要
- 印刷時に印刷対象外のアレルギーが表示される不具合を修正しました。

## スクリーンショット
### 変更前
<img width="1310" height="871" alt="image" src="https://github.com/user-attachments/assets/a62982dc-0222-4937-9b2e-5507b394a309" />


### 変更後
<img width="1326" height="862" alt="image" src="https://github.com/user-attachments/assets/b48d8384-1c2a-4f71-bacd-b00cdc282c96" />
