### PR TITLE
head 内のアセット読み込み構成を整理

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -23,7 +23,6 @@ html lang="ja"
     link rel="icon" href="/icon.svg" type="image/svg+xml"
     link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" sizes="180x180"
     = stylesheet_link_tag 'https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.css'
-    = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = stylesheet_link_tag 'tailwind', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
 


### PR DESCRIPTION
## 概要
- head 内のアセット読み込み構成を整理しました。

## 変更内容
- tom-select の読み込みを `stylesheet_link_tag` に変更しました。
- `application` の読み込みを削除し、Tailwind 経由の読み込みに一本化しました。

## スクリーンショット
- 内部処理の変更であり、見た目上の変更はないため、省略いたします。