### PR TITLE
トップページの履歴書の最終更新日付を関連するモデルの更新に合わせて更新するように修正

### DIFF
--- a/app/models/allergy.rb
+++ b/app/models/allergy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Allergy < ApplicationRecord
-  belongs_to :skincare_resume
+  belongs_to :skincare_resume, touch: true
   validates :name, presence: true
 
   scope :order_for_display, -> { order(id: :asc) }

--- a/app/models/medication.rb
+++ b/app/models/medication.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Medication < ApplicationRecord
-  belongs_to :skincare_resume
+  belongs_to :skincare_resume, touch: true
   validates :name, presence: true
 
   scope :order_for_display, -> {

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Product < ApplicationRecord
-  belongs_to :skincare_resume
+  belongs_to :skincare_resume, touch: true
   validates :name, presence: true
 
   scope :order_for_display, -> {

--- a/app/models/treatment.rb
+++ b/app/models/treatment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Treatment < ApplicationRecord
-  belongs_to :skincare_resume
+  belongs_to :skincare_resume, touch: true
   validates :name, presence: true
 
   scope :order_for_display, -> {


### PR DESCRIPTION
## 概要
- 関連モデル（スキンケア製品など）の更新時に、履歴書の最終更新日が正しく反映されるよう修正しました。

## 変更前
- スキンケア製品等の入力内容を更新しても、履歴書自体は更新されないため、トップページの最終更新日が作成日時のままとなっていた。

## 変更後
- 関連モデル更新時に履歴書の`updated_at`が更新されるようになり、トップページの最終更新日が実際の更新内容に応じた日時になるようになった。