### PR TITLE
タイムゾーンを日本時間（Tokyo）に修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module SkincareResumeApp
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = 'Tokyo'
     # config.eager_load_paths << Rails.root.join("extras")
     config.solid_queue.supervisor_pidfile = Rails.application.root.join('tmp/pids/solid_queue_supervisor.pid')
   end


### PR DESCRIPTION
## 概要
- 履歴書の日付が実際の日付より前日で表示される不具合を修正するため、タイムゾーンを日本時間（Tokyo）に変更しました。