### PR TITLE
デザインレビューのため、allow_browser を一時的に無効化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # allow_browser versions: :modern
   helper_method :current_user
 
   def current_user


### PR DESCRIPTION
## 概要
- デザインレビューのため、allow_browser を一時的に無効化しました。