### PR TITLE
表示モードから編集モードに切り替える編集ボタンを追加

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -16,11 +16,11 @@
   }
 
   .primary-button {
-    @apply inline-flex items-center justify-center h-10 w-24 rounded bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-base font-normal text-white cursor-pointer;
+    @apply inline-flex items-center justify-center h-10 w-full sm:w-24 sm:shrink-0 rounded bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-base font-normal text-white cursor-pointer;
   }
 
   .cancel-button {
-    @apply inline-flex items-center justify-center h-10 w-24 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 active:bg-gray-200 text-base font-normal;
+    @apply inline-flex items-center justify-center h-10 w-full sm:w-24 sm:shrink-0 rounded border border-gray-300 bg-gray-100 hover:bg-gray-50 active:bg-gray-200 text-base font-normal;
   }
 
   .non-printable-badge {

--- a/app/views/allergies/_allergy.html.slim
+++ b/app/views/allergies/_allergy.html.slim
@@ -1,9 +1,12 @@
 = turbo_frame_tag dom_id(allergy) do
-  = link_to edit_allergy_path(allergy), class: 'cursor-pointer' do
-    .mx-auto.max-w-4xl.mb-3.px-6.pt-6.pb-10.bg-white.border.border-gray-200.shadow.sm:pb-16
-      .w-full
+  .mx-auto.max-w-4xl.bg-white.border.border-gray-200.shadow.mb-3.px-6.pt-6
+    .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
+      .w-full.space-y-3.pb-2.sm:pb-10
         .max-w-md.space-y-2
           label.block.text-base.font-semibold
             = Allergy.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = allergy.name
+      = link_to '編集する',
+                edit_allergy_path(allergy),
+                class: 'primary-button'

--- a/app/views/allergies/_allergy.html.slim
+++ b/app/views/allergies/_allergy.html.slim
@@ -7,6 +7,6 @@
             = Allergy.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = allergy.name
-      = link_to '編集する',
+      = link_to t('buttons.edit'),
                 edit_allergy_path(allergy),
                 class: 'primary-button'

--- a/app/views/allergies/_form.html.slim
+++ b/app/views/allergies/_form.html.slim
@@ -24,7 +24,7 @@
                    attribute: Allergy.human_attribute_name(:name),
                    message: allergy.errors[:name].first)
 
-      .flex.space-x-2.justify-between.sm:shrink-0
+      .flex.space-x-4.justify-between
         = link_to t('buttons.cancel'),
                   allergies_path,
                   data: { turbo_frame: form_frame_for(allergy) },

--- a/app/views/home/_resume_overview.html.slim
+++ b/app/views/home/_resume_overview.html.slim
@@ -1,5 +1,5 @@
 .my-8.text-center.print:hidden
-  = link_to t('buttons.edit'), products_path,
+  = link_to t('buttons.edit_resume'), products_path,
             class: 'action-button-base min-w-60 px-6 bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-white'
 
 .display-area.mb-8.print:hidden

--- a/app/views/medications/_form.html.slim
+++ b/app/views/medications/_form.html.slim
@@ -27,7 +27,7 @@
                    attribute: Medication.human_attribute_name(:name),
                    message: medication.errors[:name].first)
 
-      .flex.space-x-2.justify-between.sm:shrink-0
+      .flex.space-x-4.justify-between
         = link_to t('buttons.cancel'),
                   medications_path,
                   data: { turbo_frame: form_frame_for(medication) },

--- a/app/views/medications/_medication.html.slim
+++ b/app/views/medications/_medication.html.slim
@@ -12,6 +12,6 @@
             = Medication.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = medication.name
-      = link_to '編集する',
+      = link_to t('buttons.edit'),
                 edit_medication_path(medication),
                 class: 'primary-button'

--- a/app/views/medications/_medication.html.slim
+++ b/app/views/medications/_medication.html.slim
@@ -1,7 +1,7 @@
 = turbo_frame_tag dom_id(medication) do
-  = link_to edit_medication_path(medication), class: 'cursor-pointer' do
-    .mx-auto.max-w-4xl.mb-3.px-6.pt-6.pb-6.bg-white.border.border-gray-200.shadow.sm:pb-14
-      .w-full.space-y-3
+  .mx-auto.max-w-4xl.bg-white.border.border-gray-200.shadow.mb-3.px-6.pt-6
+    .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
+      .w-full.space-y-3.pb-2.sm:pb-8
         .max-w-md.space-y-2
           label.block.text-base.font-semibold
             = Medication.human_attribute_name(:started_on)
@@ -12,3 +12,6 @@
             = Medication.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = medication.name
+      = link_to '編集する',
+                edit_medication_path(medication),
+                class: 'primary-button'

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -27,7 +27,7 @@
                    attribute: Product.human_attribute_name(:name),
                    message: product.errors[:name].first)
 
-      .flex.space-x-2.justify-between.sm:shrink-0
+      .flex.space-x-4.justify-between
         = link_to t('buttons.cancel'),
                   products_path,
                   data: { turbo_frame: form_frame_for(product) },

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -1,7 +1,7 @@
 = turbo_frame_tag dom_id(product) do
-  = link_to edit_product_path(product), class: 'cursor-pointer' do
-    .mx-auto.max-w-4xl.mb-3.px-6.pt-6.pb-6.bg-white.border.border-gray-200.shadow.sm:pb-14
-      .w-full.space-y-3
+  .mx-auto.max-w-4xl.bg-white.border.border-gray-200.shadow.mb-3.px-6.pt-6
+    .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
+      .w-full.space-y-3.pb-2.sm:pb-8
         .max-w-md.space-y-2
           label.block.text-base.font-semibold
             = Product.human_attribute_name(:started_on)
@@ -12,3 +12,6 @@
             = Product.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
               = product.name
+      = link_to '編集する',
+                edit_product_path(product),
+                class: 'primary-button'

--- a/app/views/products/_product.html.slim
+++ b/app/views/products/_product.html.slim
@@ -12,6 +12,6 @@
             = Product.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
               = product.name
-      = link_to '編集する',
+      = link_to t('buttons.edit'),
                 edit_product_path(product),
                 class: 'primary-button'

--- a/app/views/treatments/_form.html.slim
+++ b/app/views/treatments/_form.html.slim
@@ -27,7 +27,7 @@
                    attribute: Treatment.human_attribute_name(:name),
                    message: treatment.errors[:name].first)
 
-      .flex.space-x-2.justify-between.sm:shrink-0
+      .flex.space-x-4.justify-between
         = link_to t('buttons.cancel'),
                   treatments_path,
                   data: { turbo_frame: form_frame_for(treatment) },

--- a/app/views/treatments/_treatment.html.slim
+++ b/app/views/treatments/_treatment.html.slim
@@ -12,6 +12,6 @@
             = Treatment.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = treatment.name
-      = link_to '編集する',
+      = link_to t('buttons.edit'),
                 edit_treatment_path(treatment),
                 class: 'primary-button'

--- a/app/views/treatments/_treatment.html.slim
+++ b/app/views/treatments/_treatment.html.slim
@@ -1,7 +1,7 @@
 = turbo_frame_tag dom_id(treatment) do
-  = link_to edit_treatment_path(treatment), class: 'cursor-pointer' do
-    .mx-auto.max-w-4xl.mb-3.px-6.pt-6.pb-6.bg-white.border.border-gray-200.shadow.sm:pb-14
-      .w-full.space-y-3
+  .mx-auto.max-w-4xl.bg-white.border.border-gray-200.shadow.mb-3.px-6.pt-6
+    .flex.flex-col.pb-6.gap-4.sm:flex-row.sm:items-end
+      .w-full.space-y-3.pb-2.sm:pb-8
         .max-w-md.space-y-2
           label.block.text-base.font-semibold
             = Treatment.human_attribute_name(:treated_on)
@@ -12,3 +12,6 @@
             = Treatment.human_attribute_name(:name)
           .block.px-3.py-2.border.border-gray-400.rounded.shadow-sm.text-base
             = treatment.name
+      = link_to '編集する',
+                edit_treatment_path(treatment),
+                class: 'primary-button'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -75,7 +75,8 @@ ja:
       login: 履歴書を新規作成する
       guest: ログインせずに履歴書を作成
     save: 保存する
-    edit: 保存した履歴書を編集・更新する
+    edit: 編集する
+    edit_resume: 保存した履歴書を編集・更新する
     print: 印刷する
     back_to_home: トップページに戻る
     cancel: キャンセル

--- a/test/system/allergies_test.rb
+++ b/test/system/allergies_test.rb
@@ -41,9 +41,9 @@ class AllergiesTest < ApplicationSystemTestCase
 
     visit allergies_url
     allergy = Allergy.find_by!(name: '金属(亜鉛)')
-    find("##{dom_id(allergy)}").click
 
     within "##{dom_id(allergy)}" do
+      click_on '編集する'
       find('.ts-control').click
       find('.ts-dropdown-content .option', text: '花粉(ヒノキ)').click
       click_on '更新する'
@@ -56,9 +56,9 @@ class AllergiesTest < ApplicationSystemTestCase
 
     visit allergies_url
     allergy = Allergy.find_by!(name: '金属(亜鉛)')
-    find("##{dom_id(allergy)}").click
 
     within "##{dom_id(allergy)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end
@@ -103,9 +103,9 @@ class AllergiesTest < ApplicationSystemTestCase
     assert_selector '#allergies', text: '金属(金)'
 
     allergy = Allergy.find_by!(name: '金属(金)')
-    find("##{dom_id(allergy)}").click
 
     within "##{dom_id(allergy)}" do
+      click_on '編集する'
       find('.ts-control').click
       find('.ts-dropdown-content .option', text: '花粉(ヒノキ)').click
       click_on '更新する'
@@ -120,9 +120,9 @@ class AllergiesTest < ApplicationSystemTestCase
     assert_selector '#allergies', text: '金属(金)'
 
     allergy = Allergy.find_by!(name: '金属(金)')
-    find("##{dom_id(allergy)}").click
 
     within "##{dom_id(allergy)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end

--- a/test/system/medications_test.rb
+++ b/test/system/medications_test.rb
@@ -31,9 +31,9 @@ class MedicationsTest < ApplicationSystemTestCase
 
     visit medications_url
     medication = Medication.find_by!(name: 'ベピオゲル')
-    find("##{dom_id(medication)}").click
 
     within "##{dom_id(medication)}" do
+      click_on '編集する'
       fill_in '薬名', with: 'ベピオウォッシュゲル'
       click_on '更新する'
       assert_text 'ベピオウォッシュゲル'
@@ -45,9 +45,9 @@ class MedicationsTest < ApplicationSystemTestCase
 
     visit medications_url
     medication = Medication.find_by!(name: 'ベピオゲル')
-    find("##{dom_id(medication)}").click
 
     within "##{dom_id(medication)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end
@@ -86,9 +86,9 @@ class MedicationsTest < ApplicationSystemTestCase
     assert_selector '#medications', text: 'ベピオローション'
 
     medication = Medication.find_by!(name: 'ベピオローション')
-    find("##{dom_id(medication)}").click
 
     within "##{dom_id(medication)}" do
+      click_on '編集する'
       fill_in '薬名', with: 'ベピオウォッシュゲル'
       click_on '更新する'
       assert_text 'ベピオウォッシュゲル'
@@ -102,9 +102,9 @@ class MedicationsTest < ApplicationSystemTestCase
     assert_selector '#medications', text: 'ベピオローション'
 
     medication = Medication.find_by!(name: 'ベピオローション')
-    find("##{dom_id(medication)}").click
 
     within "##{dom_id(medication)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -31,9 +31,9 @@ class ProductsTest < ApplicationSystemTestCase
 
     visit products_url
     product = Product.find_by!(name: 'コラージュリペアミルク')
-    find("##{dom_id(product)}").click
 
     within "##{dom_id(product)}" do
+      click_on '編集する'
       fill_in 'スキンケア製品名', with: 'NAVISION TAホワイトエマルジョン'
       click_on '更新する'
       assert_text 'NAVISION TAホワイトエマルジョン'
@@ -48,6 +48,7 @@ class ProductsTest < ApplicationSystemTestCase
     find("##{dom_id(product)}").click
 
     within "##{dom_id(product)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end
@@ -86,9 +87,9 @@ class ProductsTest < ApplicationSystemTestCase
     assert_selector '#products', text: 'NAVISION TAホワイトローション'
 
     product = Product.find_by!(name: 'NAVISION TAホワイトローション')
-    find("##{dom_id(product)}").click
 
     within "##{dom_id(product)}" do
+      click_on '編集する'
       fill_in 'スキンケア製品名', with: 'NAVISION TAホワイトエマルジョン'
       click_on '更新する'
       assert_text 'NAVISION TAホワイトエマルジョン'
@@ -102,9 +103,9 @@ class ProductsTest < ApplicationSystemTestCase
     assert_selector '#products', text: 'NAVISION TAホワイトローション'
 
     product = Product.find_by!(name: 'NAVISION TAホワイトローション')
-    find("##{dom_id(product)}").click
 
     within "##{dom_id(product)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end

--- a/test/system/treatments_test.rb
+++ b/test/system/treatments_test.rb
@@ -31,9 +31,9 @@ class TreatmentsTest < ApplicationSystemTestCase
 
     visit treatments_url
     treatment = Treatment.find_by!(name: 'ミラノリピール')
-    find("##{dom_id(treatment)}").click
 
     within "##{dom_id(treatment)}" do
+      click_on '編集する'
       fill_in '治療名', with: 'イオン導入'
       click_on '更新する'
       assert_text 'イオン導入'
@@ -45,9 +45,9 @@ class TreatmentsTest < ApplicationSystemTestCase
 
     visit treatments_url
     treatment = Treatment.find_by!(name: 'ミラノリピール')
-    find("##{dom_id(treatment)}").click
 
     within "##{dom_id(treatment)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end
@@ -86,9 +86,9 @@ class TreatmentsTest < ApplicationSystemTestCase
     assert_selector '#treatments', text: 'ヤグレーザー'
 
     treatment = Treatment.find_by!(name: 'ヤグレーザー')
-    find("##{dom_id(treatment)}").click
 
     within "##{dom_id(treatment)}" do
+      click_on '編集する'
       fill_in '治療名', with: 'イオン導入'
       click_on '更新する'
       assert_text 'イオン導入'
@@ -102,9 +102,9 @@ class TreatmentsTest < ApplicationSystemTestCase
     assert_selector '#treatments', text: 'ヤグレーザー'
 
     treatment = Treatment.find_by!(name: 'ヤグレーザー')
-    find("##{dom_id(treatment)}").click
 
     within "##{dom_id(treatment)}" do
+      click_on '編集する'
       accept_confirm '本当に削除しますか？' do
         find('.trash-button').click
       end


### PR DESCRIPTION
## Issue
- #239 

## 概要
- 表示モードから編集モードへ切り替える「編集ボタン」を追加しました。

## 主な変更内容
- ユーザーの操作を分かりやすくするため、表示欄クリックによる編集モード遷移を廃止し、編集ボタンによる明示的な操作に変更しました。
- 上記変更に伴い、システムテストを修正しました。

## スクリーンショット
### 変更前
<img width="1918" height="1092" alt="image" src="https://github.com/user-attachments/assets/17b54835-93df-49f6-95d6-89ecf7aca84a" />
<img width="1918" height="1088" alt="image" src="https://github.com/user-attachments/assets/1c06b4d5-3294-44c1-a5f4-730e4bec7346" />

### 変更後
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/96b3bf40-6a99-4f06-a5ce-1688acebf941" />

<img width="1918" height="1088" alt="image" src="https://github.com/user-attachments/assets/1c06b4d5-3294-44c1-a5f4-730e4bec7346" />
