### PR TITLE
プログレスバーのスペースを調整

### DIFF
--- a/app/views/shared/_progress_bar.html.slim
+++ b/app/views/shared/_progress_bar.html.slim
@@ -4,4 +4,4 @@
     - skincare_steps.each do |key, label|
       .flex.flex-col.items-center
         div class=step_circle_class(key, controller_name)
-        .text-sm.text-center.font-semibold = label
+        .text-sm.text-center.font-semibold.pt-1 = label


### PR DESCRIPTION
## Issue
- #240 

## 概要
- プログレスバーのレイアウトを調整しました。

## 主な変更点
- 視認性を向上させるため、プログレスバーの丸とタイトル間のスペースを4pxに調整しました。

## スクリーンショット
### 変更前
<img width="906" height="117" alt="image" src="https://github.com/user-attachments/assets/2ce7b07a-89e7-4c47-82ca-e7e12e4e0502" />


### 変更後
<img width="940" height="117" alt="image" src="https://github.com/user-attachments/assets/a7af9e0f-589e-4024-8519-3e09278fbe67" />
