### PR TITLE
前へ / 次へボタンに矢印を追加

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,20 +1,38 @@
 # frozen_string_literal: true
 
 module NavigationHelper
-  def nav_button(label, path)
-    if path.present?
-      link_to label,
-              path,
-              class: %w[
-                inline-flex items-center justify-center
-                h-10 w-24
-                border border-[#5F7F67]
-                rounded shadow-sm
-                bg-white hover:bg-[#F3F7F4] active:bg-[#E3EAE5]
-                text-base text-[#5F7F67] font-medium
-              ]
+  def nav_button(label, path, direction:)
+    return content_tag(:span, '', class: 'w-24') if path.blank?
+
+    link_to path,
+            class: %w[
+              inline-flex items-center
+              h-10 w-24
+              border border-[#5F7F67]
+              rounded shadow-sm
+              bg-white hover:bg-[#F3F7F4] active:bg-[#E3EAE5]
+              text-base text-[#5F7F67] font-medium
+            ] do
+      content_tag(:span, class: 'flex items-center w-full px-4') do
+        safe_join(
+          [
+            content_tag(:span, arrow(direction, :left), class: 'text-left'),
+            content_tag(:span, label, class: 'flex-1 text-center'),
+            content_tag(:span, arrow(direction, :right), class: 'text-right')
+          ]
+        )
+      end
+    end
+  end
+
+  def arrow(direction, position)
+    case [direction, position]
+    when %i[previous left]
+      t('buttons.navigation.previous_icon')
+    when %i[next right]
+      t('buttons.navigation.next_icon')
     else
-      content_tag(:span, '', class: 'w-24')
+      ''
     end
   end
 end

--- a/app/views/shared/_navigation.html.slim
+++ b/app/views/shared/_navigation.html.slim
@@ -1,3 +1,3 @@
 .mt-4.flex.justify-between.print:hidden
-  = nav_button(t('buttons.navigation.previous'), previous_path)
-  = nav_button(t('buttons.navigation.next'), next_path)
+  = nav_button(t('buttons.navigation.previous'), previous_path, direction: :previous)
+  = nav_button(t('buttons.navigation.next'), next_path, direction: :next)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -82,7 +82,9 @@ ja:
     cancel: キャンセル
     navigation:
       previous: 前へ
+      previous_icon: ＜
       next: 次へ
+      next_icon: ＞
   progress_bar:
     steps:
       product: スキンケア


### PR DESCRIPTION
## Issue
- #241 

## 概要
- 遷移方向を視覚的に分かりやすくするため、前へ／次へボタンに矢印（＜ ＞）を追加しました。

## 主な変更点
- 「前へ」に「＜」、「次へ」に「＞」を付与しました。
- ボタン内でテキストは中央、矢印は左右端に配置するようレイアウトを調整しました。

## スクリーンショット
### 変更前
<img width="1163" height="967" alt="image" src="https://github.com/user-attachments/assets/0877fbd2-0ef6-4ffc-8732-3c219eb104da" />

### 変更後
<img width="1197" height="966" alt="image" src="https://github.com/user-attachments/assets/537ad7a3-6a19-4322-a556-06fc87bc80a8" />
