### PR TITLE
印刷用履歴書のロゴマークの大きさを調整

### DIFF
--- a/app/views/skincare_resumes/_resume.html.slim
+++ b/app/views/skincare_resumes/_resume.html.slim
@@ -1,6 +1,6 @@
 .w-full.max-w-2xl.mx-auto
   .flex.w-full.mx-auto.max-w-4xl.items-center.mb-2.space-x-2
-    = image_tag '/Logo.png', alt: 'SkincareResume Logo', class: 'w-14 h-14 hidden print:block'
+    = image_tag '/Logo.png', alt: 'SkincareResume Logo', class: 'w-10 h-10 hidden print:block'
     h2.text-md.font-bold.sm:text-xl
       = SkincareResume.model_name.human
       br.sm:hidden


### PR DESCRIPTION
## Issue
- #242 

## 概要
- 印刷用履歴書のロゴマークの大きさを調整しました。

## 主な変更点
- 印刷用履歴書のロゴマークの大きさを`w-14 h-14`から`w-10 h-10`に変更しました。

## スクリーンショット
### 変更前
<img width="825" height="862" alt="image" src="https://github.com/user-attachments/assets/e0e4004a-368b-47ec-b8e5-0e890ae22133" />

### 変更後
<img width="817" height="857" alt="image" src="https://github.com/user-attachments/assets/e9fcef2c-5a97-4061-98ae-95bec315fc30" />
