### PR TITLE
トップページの「履歴書を編集する」「印刷する」ボタンのレイアウト調整

### DIFF
--- a/app/views/home/_resume_overview.html.slim
+++ b/app/views/home/_resume_overview.html.slim
@@ -1,6 +1,7 @@
-.my-8.text-center.print:hidden
+.flex.flex-col.gap-4.my-8.items-center.justify-center.print:hidden.sm:flex-row.sm:items-start
   = link_to t('buttons.edit_resume'), products_path,
-            class: 'action-button-base min-w-60 px-6 bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-white'
+            class: 'action-button-base min-w-40 h-12 bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-white'
+  = render 'shared/resume_print_button'
 
 .display-area.mb-8.print:hidden
   = render '/skincare_resumes/resume', resume: display_resume, update_date: resume.updated_at.to_date
@@ -8,5 +9,7 @@
 .print-area.hidden.print:block
   = render '/skincare_resumes/resume', resume: print_resume, update_date: resume.updated_at.to_date
 
-.print:hidden
+.flex.flex-col.gap-4.my-8.items-center.justify-center.print:hidden.sm:flex-row.sm:items-start
+  = link_to t('buttons.edit_resume'), products_path,
+            class: 'action-button-base min-w-40 h-12 bg-[#5F7F67] hover:bg-[#4A6652] active:bg-[#3F5746] text-white'
   = render 'shared/resume_print_button'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -76,7 +76,7 @@ ja:
       guest: ログインせずに履歴書を作成
     save: 保存する
     edit: 編集する
-    edit_resume: 保存した履歴書を編集・更新する
+    edit_resume: 履歴書を編集する
     print: 印刷する
     back_to_home: トップページに戻る
     cancel: キャンセル

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -24,7 +24,7 @@ class HomeTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: 'トップページ'
     assert_selector 'h2', text: 'スキンケアの履歴書'
-    assert_text '保存した履歴書を編集・更新する'
+    assert_text '履歴書を編集する'
   end
 
   test 'guest user can access resume form from top page' do


### PR DESCRIPTION
## Issue
- #243 

## 概要
- トップページの「履歴書を編集する」「印刷する」ボタンのレイアウトおよび文言を調整しました。

## 主な変更点
- PC：ボタンを横並びにし、履歴書の上下に配置しました。
- スマートフォン：ボタンを縦並びにし、履歴書の上下に配置しました。
- ボタン文言を「保存した履歴書を編集・更新する」から「履歴書を編集する」に変更しました。

## スクリーンショット
### 変更前
- PC
<img width="1208" height="593" alt="image" src="https://github.com/user-attachments/assets/84e3dd3d-7833-43ae-9593-68972ac02fb9" />

<img width="1230" height="355" alt="image" src="https://github.com/user-attachments/assets/38cdcaf8-a9a9-4072-af04-976f643e3fd8" />

- スマートフォン
<img width="482" height="673" alt="image" src="https://github.com/user-attachments/assets/57d3cea7-2bfb-479d-898d-b28ca8f01cab" />

<img width="490" height="507" alt="image" src="https://github.com/user-attachments/assets/49710478-959b-4316-b337-51e75d3800e8" />

### 変更後
- PC
<img width="1177" height="547" alt="image" src="https://github.com/user-attachments/assets/3d868ac6-702f-438d-812c-d5e29d02bd95" />

<img width="1216" height="392" alt="image" src="https://github.com/user-attachments/assets/46577240-c179-401f-910f-6e51d8215fee" />

- スマートフォン
<img width="482" height="691" alt="image" src="https://github.com/user-attachments/assets/2fc4d14b-6a7f-425a-b694-3f8f2d536fac" />

<img width="486" height="543" alt="image" src="https://github.com/user-attachments/assets/ec5945c6-8710-46cd-891c-040dfddca7f9" />
