### PR TITLE
スマートフォンの場合にヘッダーを中央揃えに変更

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -31,9 +31,9 @@ html lang="ja"
     #flash.fixed.top-5.right-5.z-50
       = render 'flash'
 
-    header.mt-8.px-2.print:hidden
-      .mx-auto.max-w-4xl
-        = link_to root_path, id: 'logo_title', class: 'inline-flex items-center gap-2' do
+    header.mt-8.print:hidden
+      .mx-auto.max-w-4xl.flex.justify-center.sm:justify-start
+        = link_to root_path, id: 'logo_title', class: 'flex items-center gap-2' do
           = image_tag '/Logo.png', alt: 'SkincareResume Logo', class: 'w-14 h-14'
           span.text-2xl.font-bold
             = SkincareResume.model_name.human


### PR DESCRIPTION
## Issue
- #245 

## 概要
- スマートフォンの場合にヘッダーを中央揃えに変更しました。

## 変更内容
- スマートフォンでは中央揃え、PCでは左揃えとなるよう調整しました。

## スクリーンショット
### 変更前
<img width="490" height="855" alt="image" src="https://github.com/user-attachments/assets/cc251d89-a35c-4b1f-bcad-537ca0b60bb6" />


### 変更後
<img width="487" height="857" alt="image" src="https://github.com/user-attachments/assets/a1171d1e-0bf2-41f9-a650-b4b735d05a8e" />
