### PR TITLE
トップページのコピーとレイアウトを修正

### DIFF
--- a/app/views/home/_before_login.html.slim
+++ b/app/views/home/_before_login.html.slim
@@ -1,31 +1,26 @@
-.text-center.mt-8
-  h2.text-xl.font-bold.sm:text-4xl
-    | 皮膚科での「何だっけ？」をなくす、
-    br.sm:hidden
-    | スキンケアの履歴書
+h2.mt-8.text-center.text-xl.font-bold.leading-normal.sm:text-4xl
+  | 皮膚科での「何だっけ？」をなくす、
+  br
+  | スキンケアの履歴書
 
-.mt-10.space-y-6.text-center.text-base.sm:text-xl
+.mt-10.space-y-6.text-base.leading-normal.sm:text-xl
   p
     | 皮膚科の問診や診察の場で、
-    br.sm:hidden
-    | 思い出す手間を減らし、
-    br.sm:hidden
-    | 正確な情報を伝えるためのアプリです。
+    | 使用しているスキンケアや薬、これまでの治療履歴を
+    | 思い出して説明する負担を減らし、
+    | 正確な情報を伝えられるようにするアプリです。
 
   p
-    | スキンケアや処方薬、美容施術の履歴を
-    br.sm:hidden
-    | 一つにまとめ、
-    br.sm:hidden
-    | 診察時に医師へそのまま見せられます。
+    | 日々のスキンケアや治療の記録を一つにまとめ、医師にそのまま見せられます。
 
-.max-w-2xl.mx-auto.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
-  p.mt-4.text-base.font-bold.sm:text-xl
-    = t('common.usage')
-  p.my-4.mx-4.text-sm.sm:text-base
-    | ログインなしでもすぐに使えます。
-    br.sm:hidden
-    | 保存したい場合はログインが必要です。
+.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
+  p.my-4.mx-4.text-base.font-bold.border-b.border-gray-300.pb-2.sm:text-xl
+    | 登録なしですぐに使えます
+
+  p.my-4.mx-4.text-sm.leading-loose.sm:text-base
+    | ・ ログインせずに履歴書の作成を始められます。
+    br
+    | ・ 入力した履歴書を保存したい場合はログインが必要です。
 
 .flex.flex-col.items-center.gap-4
   = button_to '/auth/google_oauth2', data: { turbo: false }, class: 'gsi-material-button'

--- a/app/views/home/_no_resume.html.slim
+++ b/app/views/home/_no_resume.html.slim
@@ -1,30 +1,25 @@
-.text-center.mt-8
-  h2.text-xl.font-bold.sm:text-4xl
-    | 履歴書を作成して、
-    br.sm:hidden
-    | 肌の情報を整理しましょう
+h2.mt-8.text-center.text-xl.font-bold.sm:text-4xl
+  | 履歴書を作成して、
+  br.sm:hidden
+  | 肌の情報を整理しましょう
 
-.mt-10.space-y-6.text-center.text-base.sm:text-xl
+.mt-10.space-y-6.text-base.sm:text-xl
   p
-    | スキンケアや処方薬、美容施術の履歴を
-    br.sm:hidden
-    | 一つにまとめて管理できます。
+    | スキンケアや処方薬、美容施術の履歴を一つにまとめて管理できます。
 
   p
-    | 作成した履歴書は保存できるため、
-    br.sm:hidden
-    | いつでも見返せます。
+    | 作成した履歴書は保存できるため、いつでも見返せます。
 
   p
-    | 診療のたびに思い出す手間を減らし、
-    br.sm:hidden
-    | 診察をよりスムーズに進められます。
+    | 診療のたびに思い出す手間を減らし、診察をよりスムーズに進められます。
 
-.max-w-2xl.mx-auto.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
-  p.mt-4.text-base.font-bold.sm:text-xl
-    = t('common.usage')
-  p.my-4.mx-4.text-sm.sm:text-base
-    | 「履歴書を新規作成する」ボタンから、すぐに入力を始められます。
+.my-10.bg-gray-100.px-6.py-2.shadow.border.border-gray-200.rounded-md
+  p.my-4.mx-4.text-base.font-bold.border-b.border-gray-300.pb-2.sm:text-xl
+    | 履歴書の作成を始めましょう
+  p.my-4.mx-4.text-sm.leading-loose.sm:text-base
+    | ・ 「履歴書を新規作成する」ボタンから入力を始められます。
+    br
+    | ・ 作成した履歴書はいつでも見返せます。
 
 .flex.justify-center
   = link_to t('buttons.create.login'), products_path,

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -3,7 +3,7 @@
               ['皮膚科の問診や診察で、情報を思い出す手間を減らすアプリです。',
                'スキンケアや処方薬、美容施術の履歴をまとめ、診察時に医師へそのまま提示できます。'].join
 
-.w-full.max-w-6xl.mx-auto
+.w-full.max-w-2xl.mx-auto
   h1.sr-only
     = t('.title')
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -112,7 +112,6 @@ ja:
     title: "%{model}の入力"
     date_blank: －
     required_mark: "*"
-    usage: 💡 ご利用方法
   date:
     abbr_day_names:
       - 日


### PR DESCRIPTION
## Issue
- #246 

## 概要
- トップページのコピーとレイアウトを改善し、読みやすさと導線を改善しました。

## 主な変更点
- トップページのコピーをより分かりやすい表現に修正しました。
- 説明文を中央揃えから左揃えに変更し、文章として読みやすくしました。
- 「ご利用方法」を削除し、ユーザーの行動を促す見出しと文章に置き換えました。

## スクリーンショット
### 変更前
- トップページ（ログイン前）
<img width="1918" height="1086" alt="image" src="https://github.com/user-attachments/assets/f980423e-e568-4ec8-b3af-73934c34388e" />

- トップページ（ログイン後・履歴書作成前）
<img width="1918" height="1088" alt="image" src="https://github.com/user-attachments/assets/cecfdb75-ce48-4d91-a3f4-5804292e432e" />

### 変更後
- トップページ（ログイン前）
<img width="1918" height="1086" alt="image" src="https://github.com/user-attachments/assets/1178b8b5-9785-4a79-aea2-0863e293be48" />

- トップページ（ログイン後・履歴書作成前）
<img width="1918" height="1087" alt="image" src="https://github.com/user-attachments/assets/51d0c21a-0edc-4608-98c5-811c03e97ba6" />
