### PR TITLE
新規フォーム入力中に「＋」クリック時、フォームが置き換わらないよう修正

### DIFF
--- a/app/javascript/controllers/new_form_controller.js
+++ b/app/javascript/controllers/new_form_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  guard(event) {
+    const frame = document.getElementById("new_form");
+    const form = frame.querySelector("form");
+
+    if (form) {
+      event.preventDefault();
+
+      frame.scrollIntoView({ behavior: "smooth" });
+      form.classList.add("transition", "duration-500", "ring", "shadow-lg");
+
+      setTimeout(() => {
+        form.classList.remove("ring", "shadow-lg");
+      }, 1000);
+    }
+  }
+}

--- a/app/views/allergies/index.html.slim
+++ b/app/views/allergies/index.html.slim
@@ -18,7 +18,9 @@
       = render 'form', allergy: Allergy.new
 
   = link_to new_allergy_path,
-            data: { turbo_frame: 'new_form' },
+            data: { turbo_frame: 'new_form',
+                    controller: 'new-form',
+                    action: 'click->new-form#guard' },
             class: 'plus-button' do
     = render 'shared/icons/plus'
 

--- a/app/views/medications/index.html.slim
+++ b/app/views/medications/index.html.slim
@@ -18,7 +18,9 @@
       = render 'form', medication: Medication.new
 
   = link_to new_medication_path,
-            data: { turbo_frame: 'new_form' },
+            data: { turbo_frame: 'new_form',
+                    controller: 'new-form',
+                    action: 'click->new-form#guard' },
             class: 'plus-button' do
     = render 'shared/icons/plus'
 

--- a/app/views/products/index.html.slim
+++ b/app/views/products/index.html.slim
@@ -18,7 +18,9 @@
       = render 'form', product: Product.new
 
   = link_to new_product_path,
-            data: { turbo_frame: 'new_form' },
+            data: { turbo_frame: 'new_form',
+                    controller: 'new-form',
+                    action: 'click->new-form#guard' },
             class: 'plus-button' do
     = render 'shared/icons/plus'
 

--- a/app/views/treatments/index.html.slim
+++ b/app/views/treatments/index.html.slim
@@ -18,7 +18,9 @@
       = render 'form', treatment: Treatment.new
 
   = link_to new_treatment_path,
-            data: { turbo_frame: 'new_form' },
+            data: { turbo_frame: 'new_form',
+                    controller: 'new-form',
+                    action: 'click->new-form#guard' },
             class: 'plus-button'
     = render 'shared/icons/plus'
 


### PR DESCRIPTION
## Issue
- #247 

## 概要
- 新規フォーム入力中に「＋」ボタンクリック時、入力内容が消えないよう（フォームが置き換わらないよう）に修正しました。

## 主な変更点
- 新規フォームがある状態で「＋」ボタンをクリックした場合に以下の挙動となるように修正しました。
  - フォームが置き換わらない
  - 既存の新規フォームへスクロールし、外枠を強調表示する

## スクリーンショット
### 変更前
[![Image from Gyazo](https://i.gyazo.com/379a8294d78522e4648789fbf7861a4d.gif)](https://gyazo.com/379a8294d78522e4648789fbf7861a4d)

### 変更後
[![Image from Gyazo](https://i.gyazo.com/aa9cb3863723414e32217ac1880f8f2a.gif)](https://gyazo.com/aa9cb3863723414e32217ac1880f8f2a)