### PR TITLE
削除ボタンの'event.stopPropagation();'を削除

### DIFF
--- a/app/views/allergies/_form.html.slim
+++ b/app/views/allergies/_form.html.slim
@@ -34,6 +34,5 @@
     - if allergy.persisted?
       = form.button formmethod: :delete,
                     data: { turbo_confirm: t('confirmation.entry_delete') },
-                    class: 'trash-button top-3 right-3',
-                    onclick: 'event.stopPropagation();'
+                    class: 'trash-button top-3 right-3'
         = render 'shared/icons/trash'

--- a/app/views/medications/_form.html.slim
+++ b/app/views/medications/_form.html.slim
@@ -37,6 +37,5 @@
     - if medication.persisted?
       = form.button formmethod: :delete,
                     data: { turbo_confirm: t('confirmation.entry_delete') },
-                    class: 'trash-button top-6 right-6',
-                    onclick: 'event.stopPropagation();'
+                    class: 'trash-button top-6 right-6'
         = render 'shared/icons/trash'

--- a/app/views/products/_form.html.slim
+++ b/app/views/products/_form.html.slim
@@ -37,6 +37,5 @@
     - if product.persisted?
       = form.button formmethod: :delete,
                     data: { turbo_confirm: t('confirmation.entry_delete') },
-                    class: 'trash-button top-6 right-6',
-                    onclick: 'event.stopPropagation();'
+                    class: 'trash-button top-6 right-6'
         = render 'shared/icons/trash'

--- a/app/views/treatments/_form.html.slim
+++ b/app/views/treatments/_form.html.slim
@@ -37,6 +37,5 @@
     - if treatment.persisted?
       = form.button formmethod: :delete,
                     data: { turbo_confirm: t('confirmation.entry_delete') },
-                    class: 'trash-button top-6 right-6',
-                    onclick: 'event.stopPropagation();'
+                    class: 'trash-button top-6 right-6'
         = render 'shared/icons/trash'


### PR DESCRIPTION
## 概要
- 表示モードから編集モードに切り替える「編集する」ボタンの追加に伴い、削除ボタンの'event.stopPropagation();'を削除しました。

## スクリーンショット
- 内部処理の変更であり、見た目上の変更はないため、省略いたします。

## 関連Issue
- https://github.com/sjabcdefin/skincare-resume/pull/229