### PR TITLE
定期削除処理の条件と頻度を変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,5 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 EXPOSE 3000
 CMD ./bin/jobs start & ./bin/rails server
 
-HEALTHCHECK --interval=5s --timeout=30s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=60s --retries=3 \
   CMD curl -f http://localhost:3000/up || exit 1

--- a/app/jobs/skincare_resumes_cleanup_job.rb
+++ b/app/jobs/skincare_resumes_cleanup_job.rb
@@ -6,7 +6,7 @@ class SkincareResumesCleanupJob < ApplicationJob
   def perform
     Rails.logger.info '[SkincareResumesCleanupJob] start'
 
-    targets = SkincareResume.where(user_id: nil)
+    targets = SkincareResume.where(user_id: nil).where('created_at < ?', 3.days.ago)
 
     target_count = targets.count
     Rails.logger.info "[SkincareResumesCleanupJob] target_count=#{target_count}"

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,4 +13,4 @@ production:
   skincare_cleanup_job:
     class: SkincareResumesCleanupJob
     args: []
-    schedule: every day at 9am
+    schedule: every sunday at 3am


### PR DESCRIPTION
## Issue
- #160 

## 概要
-  定期削除処理の条件と頻度を見直し、不要データの削除タイミングを調整しました。

## 主な変更点
- 定期削除処理の条件に、作成から3日以上経過した未紐付けデータを対象とするため、`created_at < 3.days.ago` を追加しました。
- 定期削除処理を毎日から毎週日曜日の午前3:00に変更しました。

## スクリーンショット
- 見た目上の変更はないため、省略いたします。