### PR TITLE
Validationのテストを削除

### DIFF
--- a/test/models/allergy_test.rb
+++ b/test/models/allergy_test.rb
@@ -7,16 +7,6 @@ class AllergyTest < ActiveSupport::TestCase
     @resume = skincare_resumes(:resume_with_user)
   end
 
-  test 'should not save allergy without name' do
-    allergy = @resume.allergies.new
-    assert_not allergy.save
-  end
-
-  test 'should not save allergy with blank name' do
-    allergy = @resume.allergies.new(name: '')
-    assert_not allergy.save
-  end
-
   test 'should save allergy with name' do
     allergy = @resume.allergies.new(name: '金属(酸化亜鉛)')
     assert allergy.save

--- a/test/models/medication_test.rb
+++ b/test/models/medication_test.rb
@@ -7,16 +7,6 @@ class MedicationTest < ActiveSupport::TestCase
     @resume = skincare_resumes(:resume_with_user)
   end
 
-  test 'should not save medication without name' do
-    medication = @resume.medications.new
-    assert_not medication.save
-  end
-
-  test 'should not save medication with blank name' do
-    medication = @resume.medications.new(name: '')
-    assert_not medication.save
-  end
-
   test 'should save medication with name' do
     medication = @resume.medications.new(name: 'ベピオゲル')
     assert medication.save

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -7,16 +7,6 @@ class ProductTest < ActiveSupport::TestCase
     @resume = skincare_resumes(:resume_with_user)
   end
 
-  test 'should not save product without name' do
-    product = @resume.products.new
-    assert_not product.save
-  end
-
-  test 'should not save product with blank name' do
-    product = @resume.products.new(name: '')
-    assert_not product.save
-  end
-
   test 'should save product with name' do
     product = @resume.products.new(name: 'ゼオスキン ハイドレーティングクレンザー')
     assert product.save

--- a/test/models/treatment_test.rb
+++ b/test/models/treatment_test.rb
@@ -7,16 +7,6 @@ class TreatmentTest < ActiveSupport::TestCase
     @resume = skincare_resumes(:resume_with_user)
   end
 
-  test 'should not save treatment without name' do
-    treatment = @resume.treatments.new
-    assert_not treatment.save
-  end
-
-  test 'should not save treatment with blank name' do
-    treatment = @resume.treatments.new(name: '')
-    assert_not treatment.save
-  end
-
   test 'should save treatment with name' do
     treatment = @resume.treatments.new(name: 'エレクトロポーション ケアシス')
     assert treatment.save


### PR DESCRIPTION
## Issue
- #258 

## 概要
- Validation のテストを削除しました。

## 主な変更点
- モデルテスト(ProductTest / MedicationTest / AllergyTest / TreatmentTest)から Validation のテストを削除しました。