### PR TITLE
ResumeResolverTestにnilのケースを追加

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -11,7 +11,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   test 'creates user on first login' do
     david = User.new(name: 'David', email: 'david@gmail.com')
 
-    assert_difference 'User.count', 1 do
+    assert_difference('User.count') do
       mock_google_auth david
       post '/auth/google_oauth2'
       follow_redirect!
@@ -47,7 +47,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test 'assigns resume to user when save button clicked on subsequent login' do
     stub_session('resume_uuid' => @resume.uuid) do
-      assert_difference 'SkincareResume.count', -1 do
+      assert_difference('SkincareResume.count', -1) do
         mock_google_auth @alice
         post '/auth/google_oauth2?button=save'
         follow_redirect!

--- a/test/services/resume_resolver_test.rb
+++ b/test/services/resume_resolver_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ResumeResolverTest < ActiveSupport::TestCase
-  test 'returns existing resume when logged in' do
+  test 'returns existing resume when logged in with resume' do
     alice = users(:alice)
 
     assert_no_difference('SkincareResume.count') do
@@ -12,12 +12,28 @@ class ResumeResolverTest < ActiveSupport::TestCase
     end
   end
 
-  test 'returns existing resume when guest' do
+  test 'returns nil when logged in without resume' do
+    bob = users(:bob)
+
+    assert_no_difference('SkincareResume.count') do
+      resume = ResumeResolver.new(user: bob, session: {}).call
+      assert_nil resume
+    end
+  end
+
+  test 'returns existing resume when guest with session' do
     guest_session = { 'resume_uuid' => skincare_resumes(:resume_without_user).uuid }
 
     assert_no_difference('SkincareResume.count') do
       resume = ResumeResolver.new(user: nil, session: guest_session).call
       assert_equal SkincareResume.find_by(uuid: guest_session['resume_uuid']), resume
+    end
+  end
+
+  test 'returns existing resume when guest without session' do
+    assert_no_difference('SkincareResume.count') do
+      resume = ResumeResolver.new(user: nil, session: {}).call
+      assert_nil resume
     end
   end
 end


### PR DESCRIPTION
## 概要
- ResumeResolverTestにnilのケースを追加しました。

## 主な変更点
- ResumeResolverTestに以下のケースを追加
  - ログインユーザーで Resume が存在しない場合
  - ゲストユーザーで session に uuid が存在しない場合
- SessionsControllerTestの`assert_difference`の記法を統一
  - 軽微な修正のため本ブランチに含めています