### PR TITLE
確認ページのプログレスバーが塗りつぶされない不具合を解消

### DIFF
--- a/app/helpers/progress_bar_helper.rb
+++ b/app/helpers/progress_bar_helper.rb
@@ -7,7 +7,7 @@ module ProgressBarHelper
       'medications' => t('progress_bar.steps.medication'),
       'allergies' => t('progress_bar.steps.allergy'),
       'treatments' => t('progress_bar.steps.treatment'),
-      'skincare_resumes' => t('progress_bar.steps.confirmation')
+      'confirmations' => t('progress_bar.steps.confirmation')
     }
   end
 

--- a/test/helpers/progress_bar_helper_test.rb
+++ b/test/helpers/progress_bar_helper_test.rb
@@ -13,7 +13,7 @@ class ProgressBarHelperTest < ActionView::TestCase
     assert_equal '薬', steps['medications']
     assert_equal 'アレルギー', steps['allergies']
     assert_equal '治療', steps['treatments']
-    assert_equal '確認', steps['skincare_resumes']
+    assert_equal '確認', steps['confirmations']
   end
 
   test 'step_circle_class returns active class when step is current' do


### PR DESCRIPTION
## 概要
- 確認ページのプログレスバーが塗りつぶされない不具合を解消しました。

## 主な変更点
- ProgressBarHelper の skincare_steps の確認ページのコントローラー名を`confirmations`に変更しました。

## 関連PR
- https://github.com/sjabcdefin/skincare-resume/pull/255

## スクリーンショット
### 変更前

<img width="1125" height="470" alt="image" src="https://github.com/user-attachments/assets/2398d341-82f6-4400-8456-7b731278cad4" />

### 変更後

<img width="1225" height="501" alt="image" src="https://github.com/user-attachments/assets/dda5f6fe-68f1-48d1-87f8-1107f7dd9e6e" />
