### PR TITLE
Ruby 3.3.11へのアップデート後に発生したデプロイ失敗を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips && \
+    apt-get install --no-install-recommends -y \
+      curl \
+      libjemalloc2 \
+      libvips \
+      libyaml-dev \
+      build-essential && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Set production environment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,4 +472,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   2.5.9
+  4.0.11


### PR DESCRIPTION
## Issue
- #268 

## 概要
- Ruby 3.3.11へのアップデート後に発生したデプロイ失敗を修正しました。

## 主な変更点
- Dockerfileにlibyaml-devとbuild-essentialのインストールを追加しました。