### PR TITLE
skincare_resumeのルーティング構成を整理

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   resources :medications, except: :show
   resources :products, except: :show
 
-  resource :skincare_resume do
-    resource :confirmation, only: :show, module: :skincare_resume
+  namespace :skincare_resume do
+    resource :confirmation, only: :show
   end
 
   get '/terms', to: 'static_pages#terms'


### PR DESCRIPTION
## Issue
- #287 

## 概要
- 不要なルーティング削除のため、skincare_resume のルーティング構成を見直し、resource から namespace 構成へ変更しました。