### PR TITLE
AllergiesController#indexにorder_for_displayを追加

### DIFF
--- a/app/controllers/allergies_controller.rb
+++ b/app/controllers/allergies_controller.rb
@@ -5,7 +5,7 @@ class AllergiesController < ApplicationController
   before_action :set_allergy, only: %i[edit update destroy]
 
   def index
-    @allergies = @resume&.allergies || Allergy.none
+    @allergies = @resume&.allergies&.order_for_display || Allergy.none
   end
 
   def new


### PR DESCRIPTION
## Issue
- #288 

## 概要
- AllergiesController#indexに`order_for_display`を追加し、他コントローラと並び順の仕様を統一しました。

## スクリーンショット
- `order_for_display`は`scope :order_for_display, -> { order(id: :asc) }`であり、見た目上の変更はないため、省略いたします。