### PR TITLE
Userモデルにemailのバリデーションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,5 @@
 
 class User < ApplicationRecord
   has_one :skincare_resume, inverse_of: :user, dependent: :destroy
+  validates :email, presence: true, uniqueness: true
 end

--- a/test/system/allergies_test.rb
+++ b/test/system/allergies_test.rb
@@ -149,6 +149,7 @@ class AllergiesTest < ApplicationSystemTestCase
     select_and_create_allergy(name: '金属(金)')
     assert_selector '#allergies', text: '金属(金)'
 
+    mock_google_auth
     click_on '保存する'
 
     assert_current_path root_path

--- a/test/system/medications_test.rb
+++ b/test/system/medications_test.rb
@@ -131,6 +131,7 @@ class MedicationsTest < ApplicationSystemTestCase
     create_medication(date: '2025-12-25', name: 'ベピオローション')
     assert_selector '#medications', text: 'ベピオローション'
 
+    mock_google_auth
     click_on '保存する'
 
     assert_current_path root_path

--- a/test/system/products_test.rb
+++ b/test/system/products_test.rb
@@ -132,6 +132,7 @@ class ProductsTest < ApplicationSystemTestCase
     create_product(name: 'NAVISION TAホワイトローション', date: '2025-12-25')
     assert_selector '#products', text: 'NAVISION TAホワイトローション'
 
+    mock_google_auth
     click_on '保存する'
 
     assert_current_path root_path

--- a/test/system/skincare_resumes_test.rb
+++ b/test/system/skincare_resumes_test.rb
@@ -129,6 +129,7 @@ class SkincareResumesTest < ApplicationSystemTestCase
 
     assert_selector 'h1', text: '入力したスキンケアの履歴書の確認'
 
+    mock_google_auth
     click_on '保存する'
 
     assert_current_path root_path

--- a/test/system/treatments_test.rb
+++ b/test/system/treatments_test.rb
@@ -131,6 +131,7 @@ class TreatmentsTest < ApplicationSystemTestCase
     create_treatment(date: '2025-12-25', name: 'ヤグレーザー')
     assert_selector '#treatments', text: 'ヤグレーザー'
 
+    mock_google_auth
     click_on '保存する'
 
     assert_current_path root_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,12 +25,12 @@ module ActiveSupport
 
     OmniAuth.config.test_mode = true
 
-    def mock_google_auth(user)
+    def mock_google_auth(user = nil)
       OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
         provider: 'google_oauth2',
         info: {
-          name: user.name,
-          email: user.email
+          name: user ? user.name : 'Test User',
+          email: user ? user.email : 'test@example.com'
         }
       )
     end


### PR DESCRIPTION
## Issue
- #289 

## 概要
- Userモデルにemailのバリデーションを追加しました。

## 主な変更点
- Userモデルにemailのバリデーション(presence, uniqueness)を追加しました。
- 上記に伴い、システムテストにOmniAuthモックを追加しました。