### PR TITLE
SkincareResumeの削除対象条件をscopeに切り出し

### DIFF
--- a/app/jobs/skincare_resumes_cleanup_job.rb
+++ b/app/jobs/skincare_resumes_cleanup_job.rb
@@ -6,7 +6,7 @@ class SkincareResumesCleanupJob < ApplicationJob
   def perform
     Rails.logger.info '[SkincareResumesCleanupJob] start'
 
-    targets = SkincareResume.where(user_id: nil).where('created_at < ?', 3.days.ago)
+    targets = SkincareResume.stale_guest
 
     target_count = targets.count
     Rails.logger.info "[SkincareResumesCleanupJob] target_count=#{target_count}"

--- a/app/models/skincare_resume.rb
+++ b/app/models/skincare_resume.rb
@@ -6,4 +6,8 @@ class SkincareResume < ApplicationRecord
   has_many :allergies, dependent: :destroy
   has_many :medications, dependent: :destroy
   has_many :treatments, dependent: :destroy
+
+  scope :stale_guest, -> {
+    where(user_id: nil).where('created_at < ?', 3.days.ago)
+  }
 end

--- a/test/jobs/skincare_resumes_cleanup_job_test.rb
+++ b/test/jobs/skincare_resumes_cleanup_job_test.rb
@@ -31,17 +31,17 @@ class SkincareResumesCleanupJobTest < ActiveJob::TestCase
 
   test 'calls AdminMailer when cleanup job raises error' do
     error = StandardError.new('test error')
+    guest_mock = build_stale_guest_mock(error)
 
-    mail_mock = Minitest::Mock.new
-    mail_mock.expect(:deliver_now, true)
+    mail_mock = build_mail_mock
 
-    SkincareResume.stub :where, ->(*) { raise error } do
+    SkincareResume.stub :stale_guest, guest_mock do
       AdminMailer.stub :job_failed, mail_mock do
-        raised = assert_raises(StandardError) do
+        raised_error = assert_raises(StandardError) do
           SkincareResumesCleanupJob.perform_now
         end
 
-        assert_equal error, raised
+        assert_equal error, raised_error
       end
     end
 
@@ -50,25 +50,44 @@ class SkincareResumesCleanupJobTest < ActiveJob::TestCase
 
   test 'logs error when mail delivery fails' do
     error = StandardError.new('test error')
-    mail_error = StandardError.new('mail error')
+    guest_mock = build_stale_guest_mock(error)
 
-    mailer = Object.new
-    mailer.define_singleton_method(:deliver_now) { raise mail_error }
+    mail_error = StandardError.new('mail error')
+    mail_mock = build_mail_mock(mail_error)
 
     logs = []
 
     Rails.logger.stub :error, ->(msg) { logs << msg } do
-      SkincareResume.stub :where, ->(*) { raise error } do
-        AdminMailer.stub :job_failed, ->(*) { mailer } do
-          raised = assert_raises(StandardError) do
+      SkincareResume.stub :stale_guest, guest_mock do
+        AdminMailer.stub :job_failed, mail_mock do
+          raised_error = assert_raises(StandardError) do
             SkincareResumesCleanupJob.perform_now
           end
 
-          assert_equal error, raised
+          assert_equal error, raised_error
         end
       end
     end
 
     assert(logs.any? { |msg| msg.include?('mail_error') })
+  end
+
+  private
+
+  def build_stale_guest_mock(error)
+    mock = Minitest::Mock.new
+    mock.expect(:count, 1)
+    mock.expect(:destroy_all, nil) { raise error }
+    mock
+  end
+
+  def build_mail_mock(error = nil)
+    mock = Minitest::Mock.new
+    if error
+      mock.expect(:deliver_now, nil) { raise error }
+    else
+      mock.expect(:deliver_now, true)
+    end
+    mock
   end
 end

--- a/test/models/skincare_resume_test.rb
+++ b/test/models/skincare_resume_test.rb
@@ -30,4 +30,29 @@ class SkincareResumeTest < ActiveSupport::TestCase
       @resume.destroy!
     end
   end
+
+  test 'filters resumes older than 3 days without user' do
+    stale_guest_resume = SkincareResume.create!(
+      user: nil,
+      uuid: SecureRandom.uuid,
+      created_at: 4.days.ago
+    )
+
+    SkincareResume.create!(
+      user: nil,
+      uuid: SecureRandom.uuid,
+      created_at: 2.days.ago
+    )
+
+    SkincareResume.create!(
+      uuid: SecureRandom.uuid,
+      user: users(:alice),
+      created_at: 10.days.ago
+    )
+
+    results = SkincareResume.stale_guest
+
+    assert_includes results, stale_guest_resume
+    assert_equal 1, results.count
+  end
 end


### PR DESCRIPTION
## Issue
- #289 

## 概要
- SkincareResumeの削除対象条件をscopeに切り出しました。

## 主な変更点
- SkincareResumesCleanupJob内の `where(user_id: nil).where('created_at < ?', 3.days.ago)` をSkincareResumeモデルのscopeに移動しました。
- 上記に伴い、SkincareResumeのscopeテストを追加しました。
- 上記に伴い、SkincareResumesCleanupJobTestを修正しました。