### PR TITLE
Stimulusコントローラにdisconnectを追加しTomSelectを破棄するよう修正

### DIFF
--- a/app/javascript/controllers/select_controller.js
+++ b/app/javascript/controllers/select_controller.js
@@ -36,4 +36,10 @@ export default class extends Controller {
       wrapper.classList.add("error");
     }
   }
+
+  disconnect() {
+    if (this.ts) {
+      this.ts.destroy();
+    }
+  }
 }


### PR DESCRIPTION
## Issue
- #290 

## 概要
- Stimulusコントローラにdisconnectを追加しTomSelectを破棄するよう修正しました。

## 主な変更点
- `select_controller`に`disconnect`を追加し、TomSelect の `destroy` を実行するように修正しました。

## スクリーンショット
- 内部処理の変更であり、見た目上の変更はないため、省略いたします。