### PR TITLE
minitest-mockをインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem 'capybara'
   gem 'minitest', '~> 5.20'
+  gem 'minitest-mock', '~> 5.27'
   gem 'minitest-stub_any_instance'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
     matrix (0.4.3)
     mini_mime (1.1.5)
     minitest (5.27.0)
+    minitest-mock (5.27.0)
     minitest-stub_any_instance (1.0.3)
     msgpack (1.8.0)
     multi_xml (0.9.0)
@@ -449,6 +450,7 @@ DEPENDENCIES
   jbuilder
   kamal (= 2.11.0)
   minitest (~> 5.20)
+  minitest-mock (~> 5.27)
   minitest-stub_any_instance
   omniauth-google-oauth2
   omniauth-rails_csrf_protection


### PR DESCRIPTION
## 概要
- minitest 6系へのアップグレードに備え、`minitest/mock` が本体から削除された変更に対応するため、`minitest-mock` gem を追加しました。

## 関連PR
- https://github.com/sjabcdefin/skincare-resume/pull/284